### PR TITLE
Fix flaky test caused by empty row generation

### DIFF
--- a/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/MovingAverageIterable.java
+++ b/extensions-contrib/moving-average-query/src/main/java/org/apache/druid/query/movingaverage/MovingAverageIterable.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -137,7 +138,7 @@ public class MovingAverageIterable implements Iterable<Row>
 
     private final List<DimensionSpec> dims;
     // Key: Row's dimension set. Value: Averager. See MovingAverageIterator#computeMovingAverage for more details.
-    private final Map<Map<String, Object>, List<Averager<?>>> averagers = new HashMap<>();
+    private final Map<Map<String, Object>, List<Averager<?>>> averagers = new LinkedHashMap<>();
     private final List<AveragerFactory<?, ?>> averagerFactories;
 
     private Yielder<RowBucket> yielder;
@@ -222,7 +223,7 @@ public class MovingAverageIterable implements Iterable<Row>
               throw new NoSuchElementException();
             }
           } else {
-            Set<Map<String, Object>> averagerKeys = new HashSet<>(averagers.keySet());
+            Set<Map<String, Object>> averagerKeys = new LinkedHashSet<>(averagers.keySet());
             averagerKeys.removeAll(seenKeys);
             averagersKeysIter = averagerKeys.iterator();
             cacheIter = null;

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageIterableTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageIterableTest.java
@@ -519,12 +519,12 @@ public class MovingAverageIterableTest extends InitializedNullHandlingTest
 
     Assert.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("u", (result.getDimension("gender")).get(0));
+    Assert.assertEquals("f", (result.getDimension("gender")).get(0));
     Assert.assertEquals(JAN_2, (result.getTimestamp()));
 
     Assert.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("f", (result.getDimension("gender")).get(0));
+    Assert.assertEquals("u", (result.getDimension("gender")).get(0));
     Assert.assertEquals(JAN_2, (result.getTimestamp()));
 
     // Jan 3
@@ -551,12 +551,12 @@ public class MovingAverageIterableTest extends InitializedNullHandlingTest
 
     Assert.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("u", (result.getDimension("gender")).get(0));
+    Assert.assertEquals("f", (result.getDimension("gender")).get(0));
     Assert.assertEquals(JAN_4, (result.getTimestamp()));
 
     Assert.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("f", (result.getDimension("gender")).get(0));
+    Assert.assertEquals("u", (result.getDimension("gender")).get(0));
     Assert.assertEquals(JAN_4, (result.getTimestamp()));
 
     Assert.assertFalse(iter.hasNext());


### PR DESCRIPTION
### Addressing Non-Determinism by Changing `averagers` from `HashMap` to `LinkedHashMap`

- **Issue**: The `averagerKeys` set was being created from `averagers.keySet()`. Since `averagers` was a `HashMap`, the order of keys in `averagerKeys` was not guaranteed, leading to non-deterministic behavior.
- **Solution**: By changing `averagers` to a `LinkedHashMap`, we ensure that the keys are always in a consistent order when creating `averagerKeys`.

- **Issue**: While generating empty rows, iteration over `averagerKeys` (previously a `HashSet`) caused non-deterministic ordering, leading to flaky tests.
- **Solution**: This was resolved by changing `averagerKeys` to a `LinkedHashSet`, which maintains insertion order and ensures consistent behavior in tests.


To reproduce the flaky tests run - 
`mvn -pl extensions-contrib/moving-average-query  edu.illinois:nondex-maven-plugin:2.1.7:nondex  -Dtest=org.apache.druid.query.movingaverage.MovingAverageIterableTest#testMissingDataAtMiddle`